### PR TITLE
Minor cudf serialization improvements

### DIFF
--- a/python/cudf/comm/serialize.py
+++ b/python/cudf/comm/serialize.py
@@ -1,8 +1,8 @@
 import functools
 
-from distributed.protocol.cuda import cuda_serialize, cuda_deserialize
-from distributed.protocol import serialize, deserialize
-
 def register_distributed_serializer(cls):
+    from distributed.protocol.cuda import cuda_serialize, cuda_deserialize
+    from distributed.protocol import serialize, deserialize
+    
     cuda_serialize.register(cls)(functools.partial(cls.serialize, serialize=serialize))
     cuda_deserialize.register(cls)(functools.partial(cls.deserialize, deserialize))

--- a/python/cudf/dataframe/dataframe.py
+++ b/python/cudf/dataframe/dataframe.py
@@ -28,6 +28,7 @@ from cudf.dataframe.series import Series
 from cudf.settings import NOTSET, settings
 from cudf.comm.serialize import register_distributed_serializer
 from cudf.dataframe.categorical import CategoricalColumn
+from cudf.dataframe.column import Column
 from cudf.dataframe.buffer import Buffer
 from cudf.bindings.nvtx import nvtx_range_push, nvtx_range_pop
 from cudf._sort import get_sorted_inds
@@ -129,6 +130,8 @@ class DataFrame(object):
         columns = [col._column for col in self._cols.values()]
         serialized_columns = zip(*map(serialize, columns))
         header['columns'], column_frames = serialized_columns
+        for h, f in zip(header['columns'], column_frames):
+            h['frame_count'] = len(f)
         header['column_names'] = tuple(self._cols)
         for f in column_frames:
             frames.extend(f)

--- a/python/cudf/dataframe/index.py
+++ b/python/cudf/dataframe/index.py
@@ -455,7 +455,6 @@ class GenericIndex(Index):
             values = NumericalColumn(data=Buffer(values), dtype=values.dtype)
 
         assert isinstance(values, columnops.TypedColumnBase), type(values)
-        assert values.null_count == 0
 
         self._values = values
         self.name = name


### PR DESCRIPTION
In response to discussion in [PR#1947](https://github.com/rapidsai/cudf/pull/1947).  I made some very minor changes to get **most** serialization tests to pass in cuDF.  Some important notes:

- The `pd.util.testing.makeBoolIndex` parameterization was removed for `test_serialize`, becuase `cudf.from_pandas` does not support BoolIndex.
- Currently, `test_serialize_groupby` is the only test that is failing.  However, `test_serialize_string` also fails whenever the groupby test is also executed (it passes otherwise).
- In order to handle cases with null values in the index (during initialization), `assert values.null_count == 0` was removed from the `GenericIndex` constructor (see [Issue #1968](https://github.com/rapidsai/cudf/issues/1968))

<!--

Thanks for wanting to contribute to PyGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to 
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
